### PR TITLE
add webpack config file, tell webpack about mjs files

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,19 @@
+const config = {
+  mode: 'production', // "production" | "development" | "none"
+  resolve: {
+    // .mjs needed for https://github.com/graphql/graphql-js/issues/1272
+    extensions: ['*', '.mjs', '.js', '.json']
+  },
+  module: {
+    rules: [
+      // fixes https://github.com/graphql/graphql-js/issues/1272
+      {
+        test: /\.mjs$/,
+        include: /node_modules/,
+        type: 'javascript/auto'
+      }
+    ]
+  }
+}
+
+module.exports = config

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,12 +1,10 @@
 const config = {
   mode: 'production', // "production" | "development" | "none"
   resolve: {
-    // .mjs needed for https://github.com/graphql/graphql-js/issues/1272
     extensions: ['*', '.mjs', '.js', '.json']
   },
   module: {
     rules: [
-      // fixes https://github.com/graphql/graphql-js/issues/1272
       {
         test: /\.mjs$/,
         include: /node_modules/,


### PR DESCRIPTION
this PR will fix the webpack error about `.mjs` JavaScript modules files. 😄 

short story:  it looks like we cannot consume javascript modules (`.mjs`) files in webpack 4 without telling webpack how to parse those files.  the solution that I suggest adds a `webpack.config.js` file that tells webpack how to parse the `.mjs` file that `d3-circular-sankey` ships.

an example to demonstrate a client-code fix for https://github.com/tomshanley/d3-sankey-circular/issues/32